### PR TITLE
fix(ClamAVBaseTask): Use original scan's IPAddress

### DIFF
--- a/code/tasks/ClamAVBaseTask.php
+++ b/code/tasks/ClamAVBaseTask.php
@@ -57,6 +57,14 @@ class ClamAVBaseTask extends BuildTask
                 continue;
             }
             $logRecord = $file->scanForVirus();
+
+            // scans by a job/task will have an IPAddress of 127.0.0.1
+            $originalScan = $file->ClamAVScans()->sort('Created DESC')->first();
+            if (isset($originalScan) && isset($originalScan->IPAddress)) {
+                // replace 127.0.0.1 with original IPAddress
+                $logRecord->IPAddress = $originalScan->IPAddress;
+            }
+
             if ($logRecord === ClamAV::OFFLINE) {
                 $this->log('ClamAV daemon is offline.', 'error');
 


### PR DESCRIPTION
- The purpose of the `IPAddress` field is to mark a file's original source/uploader.
- When a scan is performed by job/task, `IPAddress` is given a value of `127.0.0.1`.
- This isn't very usefull, except perhaps in highlighting that a job/task ran this scan.
- This PR replaces `127.0.0.1` with the original/first scan's IPAddress.

This logic could also go in `ClamAV::getIP`?
This change requires further testing.

