### PR TITLE
BUG Message sanitisiation

### DIFF
--- a/src/Tasks/ClamAVBaseTask.php
+++ b/src/Tasks/ClamAVBaseTask.php
@@ -4,6 +4,7 @@ namespace Symbiote\SteamedClams\Tasks;
 
 use Exception;
 use Psr\Log\LoggerInterface;
+use SilverStripe\Core\Convert;
 use SilverStripe\Core\Injector\Injector;
 use SilverStripe\Dev\BuildTask;
 use SilverStripe\ORM\DataList;
@@ -134,11 +135,11 @@ class ClamAVBaseTask extends BuildTask
 
         switch ($type) {
             case '':
-                DB::alteration_message($message);
+                DB::alteration_message(Convert::raw2xml($message));
                 break;
 
             case 'created':
-                DB::alteration_message($message, 'created');
+                DB::alteration_message(Convert::raw2xml($message), 'created');
                 break;
 
             case 'error':
@@ -148,12 +149,12 @@ class ClamAVBaseTask extends BuildTask
                 break;
 
             case 'changed':
-                DB::alteration_message($message, 'changed');
+                DB::alteration_message(Convert::raw2xml($message), 'changed');
                 break;
 
             case 'notice':
             case 'warning':
-                DB::alteration_message($message, 'notice');
+                DB::alteration_message(Convert::raw2xml($message), 'notice');
                 break;
 
             default:


### PR DESCRIPTION
DB::alteration_message() can be executed both in CLI and web-based contexts.
Although it doesn't spell this out, it expects sanitised input,
and does not provide any further sanitisation.
That's hard to retrofit since the method is already used
in core to provide HTML formatted messages.