### PR TITLE
BUG Hide ClamAVScan from used on table

### DIFF
--- a/_config/extensions.yml
+++ b/_config/extensions.yml
@@ -7,3 +7,6 @@ SilverStripe\Assets\File:
 SilverStripe\SiteConfig\SiteConfig:
   extensions:
     -  Symbiote\SteamedClams\Extension\ClamAVSiteConfigExtension
+SilverStripe\Admin\Forms\UsedOnTable:
+  extensions:
+    - Symbiote\SteamedClams\Extension\ClamAVUsedOnTableExtension

--- a/src/Extension/ClamAVUsedOnTableExtension.php
+++ b/src/Extension/ClamAVUsedOnTableExtension.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Symbiote\SteamedClams\Extension;
+
+use SilverStripe\Core\Extension;
+use Symbiote\SteamedClams\Model\ClamAVScan;
+
+/**
+ * Hides Clam AV Scans from file used on table
+ */
+class ClamAVUsedOnTableExtension extends Extension
+{
+    /**
+     * @var string[] $excludedClasses
+     */
+    public function updateUsageExcludedClasses(&$excludedClasses)
+    {
+        $excludedClasses[] = ClamAVScan::class;
+    }
+}

--- a/tests/ClamAVUsedOnTableExtensionTest.php
+++ b/tests/ClamAVUsedOnTableExtensionTest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Symbiote\SteamedClams;
+
+use SilverStripe\Control\Director;
+use SilverStripe\Core\Injector\Injector;
+use SilverStripe\Dev\SapphireTest;
+use Symbiote\SteamedClams\Extension\ClamAVUsedOnTableExtension;
+use Symbiote\SteamedClams\Model\ClamAVScan;
+use SilverStripe\Assets\File;
+use SilverStripe\ORM\ValidationException;
+use SilverStripe\Assets\Dev\TestAssetStore;
+use SilverStripe\Security\BasicAuth;
+use SilverStripe\Core\Config\Config;
+
+class ClamAVUsedOnTableExtensionTest extends SapphireTest
+{
+    public function testUpdateUsageExcludedClasses()
+    {
+        $extension = new ClamAVUsedOnTableExtension();
+        $excluded = ['Page'];
+        $extension->updateUsageExcludedClasses($excluded);
+        $this->assertContains(ClamAVScan::class, $excluded, 'ClamAVScan has been added to exclusion list');
+        $this->assertContains('Page', $excluded, 'Pre-existing exclusion list entries are retained');
+    }
+}


### PR DESCRIPTION
[Silverstripe CMS 1.7.0](https://github.com/silverstripe/silverstripe-admin/issues/1098 added an improved used on table) added an improved used on table for files. However, ClamAV Scan are showing on it.

![image](https://user-images.githubusercontent.com/1168676/120249109-d86c6a00-c2cd-11eb-8b10-e217965f291b.png)

This PR excludes ClamAV Scans from the used on table. I've tested this work by deploying to a Silverstripe Cloud environment.


