### PR TITLE
feat: allow use of streams to send files to clamd

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ Symbiote\SteamedClams\ClamAV:
   deny_on_failure: false
   # For configuring on existing site builds and ignoring the scanning of pre-module install `File` records. 
   initial_scan_ignore_before_datetime: '1970-12-25 00:00:00'
+  # If true will send files to clamd as streams (by default files are referenced using their path). Useful when files are stored remotely and/or encrypted at rest.
+  use_streams: false
 ```
 
 If you have the QueuedJobs module installed, you can configure when files missed by ClamAV daemon are scanned.


### PR DESCRIPTION
Sometimes the files are stored remotely or are encrypted at rest making them unreadable/unreachable to `clamd`.

This update handles these 2 cases.

My use case was connected to the encryption at rest when files could be accessed via streams only where they were decrypted before actual use (i.e. sending). The only way to use such files was to use streams.

Same, I suppose, happens when files are stored remotely: they are streamed to the host whenever there's a need to do something with them.

This makes streams the most reliable source of accessing file data, I presume.

PS: Had to rename original `streamScan` into `stringScan` in `clamd.php` because it actually was using a string as the source.